### PR TITLE
Mount the image into the container

### DIFF
--- a/interactive_environments/paraview/templates/paraview.mako
+++ b/interactive_environments/paraview/templates/paraview.mako
@@ -19,8 +19,10 @@ else:
 
 DATASET_HID = hda.hid
 
+input_tiff = ie_request.volume(hda.file_name, '/input/input.tiff', how='ro')
+
 # Add all environment variables collected from Galaxy's IE infrastructure
-ie_request.launch(
+ie_request.launch(volumes=[input_tiff],
     image=trans.request.params.get('image_tag', None),
     additional_ids=trans.request.params.get('additional_dataset_ids', None),
     env_override={


### PR DESCRIPTION
This is not strictly needed and has a the disadvantage of requiring a shared filesystem between the Docker host and the Galaxy host, but it's for now the easiest way to get started.

The other option would be to integrate a bioblend script that copies the into the container over http.
If the viewer supports URLs as input this would also work. Some kind of streaming API.